### PR TITLE
Added global CLI

### DIFF
--- a/bin/mezon
+++ b/bin/mezon
@@ -8,10 +8,8 @@
  */
 
 foreach ([
-        __DIR__ . '/vendor/autoload.php',
         __DIR__ . '/../vendor/autoload.php',
-        __DIR__ . '/../../autoload.php',
-        __DIR__ . '/../../vendor/autoload.php',
+        __DIR__ . '/../../../autoload.php',
     ] as $file) {
     if (file_exists($file)) {
         require($file);

--- a/bin/mezon
+++ b/bin/mezon
@@ -18,5 +18,4 @@ foreach ([
     }
 }
 
-
 \Mezon\Cli\Tool::run();

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
 			"role": "Founder"
 		}
 	],
+    "bin": [
+        "bin/mezon"
+    ],
 	"require-dev": {
 		"phpunit/phpunit": "^8.5",
 		"phpunit/php-token-stream": "3.1.2",


### PR DESCRIPTION
Now it's available to run: `composer global require mezon/cli` and the command CLI can be called anywhere.