### PR TITLE
Improve basic commands

### DIFF
--- a/Mezon/Cli/Interfaces/IVerb.php
+++ b/Mezon/Cli/Interfaces/IVerb.php
@@ -8,7 +8,7 @@ interface IVerb {
     /**
      * Method returns class name for processing command from the command line
      *
-     * @return class-string<IEntity>
+     * @return class-string<IEntity>|null
      */
     public static function getCommand();
 }

--- a/Mezon/Cli/Tests/UnexpectedParamsUnitTest.php
+++ b/Mezon/Cli/Tests/UnexpectedParamsUnitTest.php
@@ -15,15 +15,24 @@ class UnexpectedParamsUnitTest extends Base
      */
     public function testNoVerbs(): void
     {
-        // assertions
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Verbs not provided!. Try \'mezon help\' for more information.');
-
         // setup
         $this->setCommand([]);
 
         // test body
-        Tool::run();
+        $commandLineOutput = $this->testBody();
+
+        // assertions
+        $this->validateOutput($commandLineOutput, [
+            'Usage: mezon <verb> <entity> [<options>]',
+            'Verbs:',
+            '  create' . "\n",
+            '  help' . "\n",
+            '  version' . "\n",
+            'Entities:',
+            '  application' . "\n",
+            '  fs' . "\n",
+            '  htaccess' . "\n"
+        ]);
     }
 
     /**
@@ -31,17 +40,18 @@ class UnexpectedParamsUnitTest extends Base
      */
     public function testUnexpectedVerb(): void
     {
-        // assertions
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('The verb "unexpected-verb" was not found');
-
         // setup
         $this->setCommand([
             'unexpected-verb'
         ]);
 
         // test body
-        Tool::run();
+        $commandLineOutput = $this->testBody();
+
+        // assertions
+        $this->validateOutput($commandLineOutput, [
+            'The verb "unexpected-verb" was not found'
+        ]);
     }
 
     /**
@@ -49,17 +59,18 @@ class UnexpectedParamsUnitTest extends Base
      */
     public function testUnexpectedEntity(): void
     {
-        // assertions
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('The entity "unexpected entity" was not found');
-
         // setup
         $this->setCommand([
-            'create',
+           'create',
             'unexpected entity'
         ]);
 
         // test body
-        Tool::run();
+        $commandLineOutput = $this->testBody();
+
+        // test body
+       $this->validateOutput($commandLineOutput, [
+            'The entity "unexpected entity" was not found'
+        ]);
     }
 }

--- a/Mezon/Cli/Tests/VersionUnitTest.php
+++ b/Mezon/Cli/Tests/VersionUnitTest.php
@@ -23,7 +23,7 @@ class VersionUnitTest extends Base
 
         // assertions
         $this->validateOutput($commandLineOutput, [
-            'Mezon CLI 1.0.4'
+            'Mezon CLI 1.0.6'
         ]);
     }
 }

--- a/Mezon/Cli/Tool.php
+++ b/Mezon/Cli/Tool.php
@@ -32,13 +32,13 @@ class Tool
     /**
      * Method returns class name for processing verb from the command line
      *
-     * @return class-string<IVerb>
+     * @return class-string<IVerb>|null
      */
-    private static function getVerbHandler()
+    private static function getVerbHandler(): ?string
     {
         global $argv;
 
-        if (count($argv) === 1) {
+        if (! isset($argv[1])) {
             return static::$verb2Class['help'];
         }
 
@@ -46,7 +46,7 @@ class Tool
             return static::$verb2Class[$argv[1]];
         }
 
-        echo 'The verb "' . $argv[1] . '" was not found' . "\n";
+        return null;
     }
 
     /**
@@ -54,10 +54,18 @@ class Tool
      */
     public static function run(): void
     {
-        $verbHandler = static::getVerbHandler();
+        global $argv;
 
-        if ($verbHandler) {
-            $verbHandler::getCommand()::run();
+        if (! $verbHandler = static::getVerbHandler()) {
+            echo "The verb \"$argv[1]\" was not found\n";
+            return;
         }
+
+        if (! $command = $verbHandler::getCommand()) {
+            echo "The entity \"$argv[2]\" was not found\n";
+            return;
+        }
+
+        $command::run();
     }
 }

--- a/Mezon/Cli/Tool.php
+++ b/Mezon/Cli/Tool.php
@@ -44,9 +44,9 @@ class Tool
 
         if (isset(static::$verb2Class[$argv[1]])) {
             return static::$verb2Class[$argv[1]];
-        } else {
-            throw (new \Exception('The verb "' . $argv[1] . '" was not found'));
         }
+
+        echo 'The verb "' . $argv[1] . '" was not found' . "\n";
     }
 
     /**
@@ -54,6 +54,10 @@ class Tool
      */
     public static function run(): void
     {
-        static::getVerbHandler()::getCommand()::run();
+        $verbHandler = static::getVerbHandler();
+
+        if ($verbHandler) {
+            $verbHandler::getCommand()::run();
+        }
     }
 }

--- a/Mezon/Cli/Tool.php
+++ b/Mezon/Cli/Tool.php
@@ -39,7 +39,7 @@ class Tool
         global $argv;
 
         if (count($argv) === 1) {
-            throw (new \Exception('Verbs not provided!. Try \'mezon help\' for more information.'));
+            return static::$verb2Class['help'];
         }
 
         if (isset(static::$verb2Class[$argv[1]])) {

--- a/Mezon/Cli/Verbs/Create.php
+++ b/Mezon/Cli/Verbs/Create.php
@@ -38,16 +38,16 @@ class Create implements IVerb
     /**
      * Method returns class name for processing command from the command line
      *
-     * @return class-string<IEntity>
+     * @return class-string<IEntity>|null
      */
-    public static function getCommand()
+    public static function getCommand(): ?string
     {
         global $argv;
 
         if (isset(static::$entity2Class[$argv[2]])) {
             return static::$entity2Class[$argv[2]];
-        } else {
-            throw (new \Exception('The entity "' . $argv[2] . '" was not found'));
         }
+
+        return null;
     }
 }

--- a/Mezon/Cli/Verbs/Version.php
+++ b/Mezon/Cli/Verbs/Version.php
@@ -31,6 +31,6 @@ class Version implements IVerb, IEntity
      */
     public static function run(): void
     {
-        echo "Mezon CLI 1.0.4\n";
+        echo "Mezon CLI 1.0.6\n";
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         "bin/mezon"
     ],
 	"require-dev": {
-		"phpunit/phpunit": "^8.5",
-		"phpunit/php-token-stream": "3.1.2",
-		"vimeo/psalm": "^4.2",
-		"infection/infection": "^0.21.5"
+		"phpunit/phpunit": "^9.5.20",
+		"phpunit/php-token-stream": "4.0.4",
+		"vimeo/psalm": "^4.22.0",
+		"infection/infection": "^0.26.6"
 	},
 	"require": {
 		"php": ">=7.2.0",
@@ -43,5 +43,10 @@
 		"infection": "php ./vendor/infection/infection/bin/infection --min-msi=100",
 		"psalm-self": "php ./vendor/vimeo/psalm/psalm --config=psalm-self.xml --show-info=true --no-cache",
 		"test-unit": "php ./vendor/phpunit/phpunit/phpunit --testsuite unit"
+	},
+	"config": {
+		"allow-plugins": {
+			"infection/extension-installer": true
+		}
 	}
 }


### PR DESCRIPTION
Minor changes:

- Re-designed 'throw errors' with only printing messages with 'echo', it's less verbose and readable, 'throw error' can be better for development or debug purposes.

- Updated packages to the last available version (without breaking the code) to have support for PHP 8. However 'phpunit/php-token-stream' is abandoned and it doesn't have any more support.